### PR TITLE
update libraryDependencies snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project compiles to Scala 3.x and Scala 2.13.
 
 Add it as an sbt dependency:
 ```scala
-libraryDependencies += "info.umazalakain" % "errata" %% "0.1.0"
+libraryDependencies += "info.umazalakain" %% "errata" % "0.1.0"
 ```
 
 ## Rationale


### PR DESCRIPTION
I believe the `%%` is misplaced. see: https://stackoverflow.com/a/17461551/9199853

see also: https://central.sonatype.com/artifact/info.umazalakain/errata_3/overview

which suggests:

`libraryDependencies += "info.umazalakain" % "errata_3" % "0.1.0"`

as opposed to 

`libraryDependencies += "info.umazalakain" % "errata" % "0.1.0_3"`
