### PR TITLE
Move syntax type bounds to methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val scala3Version = "3.3.1"
 
 name := "errata"
 description := "Error handling made precise. Because error handling belongs in the types."
-ThisBuild / tlBaseVersion := "0.3"
+ThisBuild / tlBaseVersion := "0.4"
 ThisBuild / organization := "info.umazalakain"
 ThisBuild / organizationName := "Uma Zalakain"
 ThisBuild / startYear := Some(2023)

--- a/errata/src/main/scala/errata/syntax.scala
+++ b/errata/src/main/scala/errata/syntax.scala
@@ -37,57 +37,51 @@ object syntax {
   trait syntax[Tag[_]] {
     implicit def untag[A](fa: Tag[A]): A
 
-    implicit class RaiseSyntax[F[_], E2, E1 <: E2](err: Tag[E1])(implicit F: Raise[F, E2]) {
-      def raise[A]: F[A] = F.raise(err)
+    implicit class RaiseSyntax[E, A](err: Tag[E]) {
+      def raise[F[_]](implicit F: Raise[F, E]): F[A] = F.raise(err)
     }
 
-    implicit class EitherLiftSyntax[F[_], E2, E1 <: E2, A](either: Tag[Either[E1, A]])(implicit F: Raise[F, E2]) {
-      def liftTo(implicit A: Applicative[F]): F[A] = F.fromEither(either)
+    implicit class EitherLiftSyntax[E, A](either: Tag[Either[E, A]]) {
+      def liftTo[F[_]](implicit F: Raise[F, E], A: Applicative[F]): F[A] = F.fromEither(either)
     }
 
-    implicit class ValidatedLiftSyntax[F[_], E2, E1 <: E2, A](validated: Tag[Validated[E1, A]])(implicit
-        F: Raise[F, E2]
-    ) {
-      def liftTo(implicit A: Applicative[F]): F[A] = F.fromValidated(validated)
+    implicit class ValidatedLiftSyntax[E, A](validated: Tag[Validated[E, A]]) {
+      def liftTo[F[_]](implicit F: Raise[F, E], A: Applicative[F]): F[A] = F.fromValidated(validated)
     }
 
-    implicit class OptionLiftSyntax[F[_], E, A](option: Tag[Option[A]])(implicit F: Raise[F, E]) {
-      def liftTo(err: E)(implicit A: Applicative[F]): F[A] = F.fromOption(err)(option)
+    implicit class OptionLiftSyntax[E, A](option: Tag[Option[A]]) {
+      def liftTo[F[_]](err: E)(implicit F: Raise[F, E], A: Applicative[F]): F[A] = F.fromOption(err)(option)
     }
 
-    implicit class OptionRaiseSyntax[F[_], E2, E1 <: E2](option: Tag[Option[E1]])(implicit F: Raise[F, E2]) {
-      def raiseTo(implicit A: Applicative[F]): F[Unit] = option.fold(A.unit)(F.raise)
+    implicit class OptionRaiseSyntax[E](option: Tag[Option[E]]) {
+      def raiseTo[F[_]](implicit F: Raise[F, E], A: Applicative[F]): F[Unit] = option.fold(A.unit)(F.raise)
     }
 
-    implicit class HandleToSyntax[F[_], G[_], E, A](fa: Tag[F[A]])(implicit F: HandleTo[F, G, E]) {
-      def handleWith(f: E => G[A]): G[A] = F.handleWith(fa)(f)
-      def handle(f: E => A)(implicit AG: Applicative[G]): G[A] = F.handle(fa)(f)
-      def restore(implicit FF: Functor[F], AG: Applicative[G]): G[Option[A]] =
+    implicit class HandleToSyntax[F[_], A](fa: Tag[F[A]]) {
+      def handleWith[G[_], E](f: E => G[A])(implicit F: HandleTo[F, G, E]): G[A] = F.handleWith(fa)(f)
+      def handle[G[_], E](f: E => A)(implicit AG: Applicative[G], F: HandleTo[F, G, E]): G[A] = F.handle(fa)(f)
+      def restore[G[_], E](implicit FF: Functor[F], AG: Applicative[G], F: HandleTo[F, G, E]): G[Option[A]] =
         F.restore(fa)
-      def attempt(implicit FF: Functor[F], AG: Applicative[G]): G[Either[E, A]] =
+      def attempt[G[_], E](implicit FF: Functor[F], AG: Applicative[G], F: HandleTo[F, G, E]): G[Either[E, A]] =
         F.attempt(fa)
     }
 
-    implicit class HandleSyntax[F[_], E, A](fa: Tag[F[A]])(implicit F: Handle[F, E]) {
-      def tryHandleWith(f: E => Option[F[A]]): F[A] = F.tryHandleWith(fa)(f)
-      def tryHandle(f: E => Option[A])(implicit FF: Applicative[F]): F[A] =
+    implicit class HandleSyntax[F[_], A](fa: Tag[F[A]]) {
+      def tryHandleWith[E](f: E => Option[F[A]])(implicit F: Handle[F, E]): F[A] = F.tryHandleWith(fa)(f)
+      def tryHandle[E](f: E => Option[A])(implicit FF: Applicative[F], F: Handle[F, E]): F[A] =
         F.tryHandle(fa)(f)
-      def recoverWith(pf: PartialFunction[E, F[A]]): F[A] = F.recoverWith(fa)(pf)
-      def recover(pf: PartialFunction[E, A])(implicit AF: Applicative[F]): F[A] =
+      def recoverWith[E](pf: PartialFunction[E, F[A]])(implicit F: Handle[F, E]): F[A] = F.recoverWith(fa)(pf)
+      def recover[E](pf: PartialFunction[E, A])(implicit AF: Applicative[F], F: Handle[F, E]): F[A] =
         F.recover(fa)(pf)
-      def restoreWith(ra: => F[A]): F[A] = F.restoreWith(fa)(ra)
+      def restoreWith[E](ra: => F[A])(implicit F: Handle[F, E]): F[A] = F.restoreWith(fa)(ra)
     }
 
-    implicit class HandleByRecoverSyntax[F[_], E, A](fa: Tag[F[A]])(implicit F: Handle.ByRecover[F, E]) {
-      def recWith(pf: PartialFunction[E, F[A]]): F[A] = F.recWith(fa)(pf)
+    implicit class HandleByRecoverSyntax[F[_], A](fa: Tag[F[A]]) {
+      def recWith[E](pf: PartialFunction[E, F[A]])(implicit F: Handle.ByRecover[F, E]): F[A] = F.recWith(fa)(pf)
     }
 
-    implicit class TransformToSyntax[F[_], G[_], E1, E2, A](fa: Tag[F[A]])(implicit F: TransformTo[F, G, E1, E2]) {
-      def transform(f: E1 => E2): G[A] = F.transform(fa)(f)
-    }
-
-    implicit class ErrorsSyntax[F[_], E, A](fa: Tag[F[A]])(implicit F: Errors[F, E]) {
-      def transform(f: E => E): F[A] = F.transform(fa)(f)
+    implicit class TransformToSyntax[F[_], A](fa: Tag[F[A]]) {
+      def transform[G[_], E1, E2](f: E1 => E2)(implicit F: TransformTo[F, G, E1, E2]): G[A] = F.transform(fa)(f)
     }
   }
 }

--- a/examples/src/main/scala/httpClient.scala
+++ b/examples/src/main/scala/httpClient.scala
@@ -74,7 +74,7 @@ object httpClient extends IOApp {
         // Handle happy case
         case (_, _) => ()
       }
-      .handleWith {
+      .handleWith[H, AppError] {
         // Handle errors
         case RestAPIError(th) =>
           Console[H].println(s"REST API error: ${th.getMessage}")


### PR DESCRIPTION
Better discoverability, but it demands type parameters from the user