### PR TITLE
adding -,+ variance to Raise, HandleTo

### DIFF
--- a/errata/src/main/scala/errata/laws/ErrorsToLaws.scala
+++ b/errata/src/main/scala/errata/laws/ErrorsToLaws.scala
@@ -34,15 +34,15 @@ trait ErrorsToLaws[F[_], G[_], E] extends RaiseLaws[F, E] with HandleToLaws[F, G
   )(implicit FF: Functor[F], AG: Applicative[G]): IsEq[G[Option[A]]] =
     F.restore[A](F.raise(e)) <-> AG.pure(None: Option[A])
 
-  def raiseAttempt[A](
+  def raiseAttempt[A, EE >: E](
       e: E
-  )(implicit FF: Functor[F], AG: Applicative[G]): IsEq[G[Either[E, A]]] =
-    F.attempt[A](F.raise(e)) <-> AG.pure(Left[E, A](e))
+  )(implicit FF: Functor[F], AG: Applicative[G]): IsEq[G[Either[EE, A]]] =
+    F.attempt[A, EE](F.raise(e)) <-> AG.pure(Left[E, A](e))
 
-  def fromEitherAttempt[A](
+  def fromEitherAttempt[A, EE >: E](
       either: Either[E, A]
-  )(implicit AF: Applicative[F], AG: Applicative[G]): IsEq[G[Either[E, A]]] =
-    F.attempt[A](F.fromEither(either)) <-> AG.pure(either)
+  )(implicit AF: Applicative[F], AG: Applicative[G]): IsEq[G[Either[EE, A]]] =
+    F.attempt[A, EE](F.fromEither(either)) <-> AG.pure(either)
 
   def fromOptionRestore[A](option: Option[A], e: E)(implicit
       AF: Applicative[F],

--- a/errata/src/main/scala/errata/syntax.scala
+++ b/errata/src/main/scala/errata/syntax.scala
@@ -17,7 +17,6 @@
 package errata
 
 import cats.data.Validated
-import cats.implicits.catsSyntaxEitherId
 import cats.{Applicative, Functor, Id}
 
 object syntax {
@@ -66,7 +65,7 @@ object syntax {
       def restore(implicit FF: Functor[F], AG: Applicative[G]): G[Option[A]] =
         F.restore(fa)
       def attempt(implicit FF: Functor[F], AG: Applicative[G]): G[Either[E, A]] =
-        F.handle(FF.map(fa)(_.asRight[E]))(_.asLeft)
+        F.attempt(fa)
     }
 
     implicit class HandleSyntax[F[_], E, A](fa: Tag[F[A]])(implicit F: Handle[F, E]) {

--- a/errata/src/main/scala/errata/syntax.scala
+++ b/errata/src/main/scala/errata/syntax.scala
@@ -17,6 +17,7 @@
 package errata
 
 import cats.data.Validated
+import cats.implicits.catsSyntaxEitherId
 import cats.{Applicative, Functor, Id}
 
 object syntax {
@@ -65,7 +66,7 @@ object syntax {
       def restore(implicit FF: Functor[F], AG: Applicative[G]): G[Option[A]] =
         F.restore(fa)
       def attempt(implicit FF: Functor[F], AG: Applicative[G]): G[Either[E, A]] =
-        F.attempt(fa)
+        F.handle(FF.map(fa)(_.asRight[E]))(_.asLeft)
     }
 
     implicit class HandleSyntax[F[_], E, A](fa: Tag[F[A]])(implicit F: Handle[F, E]) {

--- a/errata/src/main/scala/errata/types.scala
+++ b/errata/src/main/scala/errata/types.scala
@@ -62,16 +62,14 @@ trait HandleTo[F[_], G[_], +E] {
       fa: F[A]
   )(implicit F: Functor[F], G: Applicative[G]): G[Option[A]] =
     handle(F.map(fa)(_.some))(_ => None)
+
+  def attempt[A, EE >: E](
+                  fa: F[A]
+                )(implicit F: Functor[F], G: Applicative[G]): G[Either[EE, A]] =
+    handle(F.map(fa)(_.asRight[EE]))(_.asLeft)
 }
 
 object HandleTo {
-
-  implicit class HandleToAttemptOps[F[_], G[_], E](handleTo: HandleTo[F, G[_], E]) {
-    def attempt[A](
-        fa: F[A]
-    )(implicit F: Functor[F], G: Applicative[G]): G[Either[E, A]] =
-      handleTo.handle(F.map(fa)(_.asRight[E]))(_.asLeft)
-  }
   def apply[F[_], G[_], E](implicit ev: HandleTo[F, G[_], E]): HandleTo[F, G[_], E] = ev
 }
 

--- a/errata/src/main/scala/errata/types.scala
+++ b/errata/src/main/scala/errata/types.scala
@@ -79,7 +79,7 @@ object HandleTo {
   """can't understand how to recover from ${E} in the type ${F}
 provide an instance of Handle[${F}, ${E}] or cats.ApplicativeError[${F}, ${E}]"""
 )
-trait Handle[F[_], E] extends HandleTo[F, F, E] {
+trait Handle[F[_], +E] extends HandleTo[F, F, E] {
 
   def tryHandleWith[A](fa: F[A])(f: E => Option[F[A]]): F[A]
 

--- a/errata/src/main/scala/errata/types.scala
+++ b/errata/src/main/scala/errata/types.scala
@@ -134,7 +134,7 @@ object ErrorsTo {
   """can't understand how to transform errors ${E1} in ${F} into errors ${E2} in ${G}
 provide an instance of TransformTo[${F}, ${G}, ${E1}, ${E2}] or cats.ApplicativeError[${F}, ${E1}] and cats.ApplicativeError[${G}, ${E2}]"""
 )
-trait TransformTo[F[_], G[_], E1, E2] extends HandleTo[F, G, E1] with Raise[G, E2] {
+trait TransformTo[F[_], G[_], +E1, -E2] extends HandleTo[F, G, E1] with Raise[G, E2] {
   def transform[A](fa: F[A])(f: E1 => E2): G[A] =
     handleWith(fa)(f `andThen` raise)
 }

--- a/errata/src/main/scala/errata/types.scala
+++ b/errata/src/main/scala/errata/types.scala
@@ -66,10 +66,10 @@ trait HandleTo[F[_], G[_], +E] {
 
 object HandleTo {
 
-  implicit class HandleToAttemptOps[F[_], G[_], E](handleTo: HandleTo[F, G[_], E]){
+  implicit class HandleToAttemptOps[F[_], G[_], E](handleTo: HandleTo[F, G[_], E]) {
     def attempt[A](
-                    fa: F[A]
-                  )(implicit F: Functor[F], G: Applicative[G]): G[Either[E, A]] =
+        fa: F[A]
+    )(implicit F: Functor[F], G: Applicative[G]): G[Either[E, A]] =
       handleTo.handle(F.map(fa)(_.asRight[E]))(_.asLeft)
   }
   def apply[F[_], G[_], E](implicit ev: HandleTo[F, G[_], E]): HandleTo[F, G[_], E] = ev

--- a/errata/src/main/scala/errata/types.scala
+++ b/errata/src/main/scala/errata/types.scala
@@ -64,8 +64,8 @@ trait HandleTo[F[_], G[_], +E] {
     handle(F.map(fa)(_.some))(_ => None)
 
   def attempt[A, EE >: E](
-                  fa: F[A]
-                )(implicit F: Functor[F], G: Applicative[G]): G[Either[EE, A]] =
+      fa: F[A]
+  )(implicit F: Functor[F], G: Applicative[G]): G[Either[EE, A]] =
     handle(F.map(fa)(_.asRight[EE]))(_.asLeft)
 }
 

--- a/errata/src/test/scala/errata/discipline/ErrorsToTests.scala
+++ b/errata/src/test/scala/errata/discipline/ErrorsToTests.scala
@@ -49,8 +49,8 @@ trait ErrorsToTests[F[_], G[_], E] extends RaiseTests[F, E] with HandleToTests[F
         "handleWith f . raise e = f" -> forAll(laws.raiseHandleWith[A] _),
         "handle f . raise e = pure f" -> forAll(laws.raiseHandle[A] _),
         "restore . raise e = pure none" -> forAll(laws.raiseRestore[A] _),
-        "attempt . raise e = pure left e" -> forAll(laws.raiseAttempt[A] _),
-        "restore . fromOption e opt = pure opt" -> forAll(laws.fromEitherAttempt[A] _),
+        "attempt . raise e = pure left e" -> forAll(laws.raiseAttempt[A, E] _),
+        "restore . fromOption e opt = pure opt" -> forAll(laws.fromEitherAttempt[A, E] _),
         "attempt . fromEither e eth = pure eth" -> forAll(laws.fromOptionRestore[A] _)
       )
     }


### PR DESCRIPTION
cat's `ApplicativeError` is invariant in E which I believe is partly the reason why we often end up with `MonadThrow` everywhere in cats-infused code. The modified version of `Raise` and `HandleTo` should allow us to say:

```scala
  sealed trait AppError extends Throwable
  sealed trait Domain1Error extends AppError
  sealed trait Domain2Error extends AppError

  def foo[F[_] : Applicative](implicit raise: Raise[F, Domain1Error]): F[Unit] = Applicative[F].unit
  def bar[F[_] : Applicative](implicit raise: Raise[F, Domain2Error]): F[Unit] = Applicative[F].unit

  import cats.ApplicativeThrow
  implicit def raiseThrow[F[_]: ApplicativeThrow]: errata.RaiseThrow[F] = {
    import errata.instances.*
    implicitly[RaiseThrow[F]]
  }

  def program[F[_] : ApplicativeThrow]: F[Unit] = foo[F] *> bar[F]
``` 

which we can't with the current version.